### PR TITLE
chore: `@SpringBootTest` 빈 비활성화

### DIFF
--- a/src/test/java/pingpong/backend/BackendApplicationTests.java
+++ b/src/test/java/pingpong/backend/BackendApplicationTests.java
@@ -1,8 +1,10 @@
 package pingpong.backend;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+@Disabled("CI에서 통합테스트 환경(DB/Redis 등) 구성 전이라 비활성화")
 @SpringBootTest
 class BackendApplicationTests {
 


### PR DESCRIPTION
### ✨ Related Issue
- #9 
---

### 📌 Task Details
- `@SpringBootTest` 테스트용 빈 삭제하기 위해 `@Disabled` 어노테이션 사용

---

### 💬 Review Requirements (Optional)

