### PR TITLE
fix: `deploy.sh` 파일 생성 방식 수정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -117,9 +117,6 @@ jobs:
           scp -o StrictHostKeyChecking=no -P ${{ secrets.PROD_EC2_PORT }} docker-compose.yml \
             ${{ secrets.PROD_EC2_USER }}@${{ secrets.PROD_EC2_HOST }}:/home/${{ secrets.PROD_EC2_USER }}/docker-compose.yml
 
-          scp -o StrictHostKeyChecking=no -P ${{ secrets.PROD_EC2_PORT }} deploy.sh \
-            ${{ secrets.PROD_EC2_USER }}@${{ secrets.PROD_EC2_HOST }}:/home/${{ secrets.PROD_EC2_USER }}/deploy.sh
-
           scp -o StrictHostKeyChecking=no -P ${{ secrets.PROD_EC2_PORT }} -r nginx \
             ${{ secrets.PROD_EC2_USER }}@${{ secrets.PROD_EC2_HOST }}:/home/${{ secrets.PROD_EC2_USER }}/nginx
 


### PR DESCRIPTION
### ✨ Related Issue
- #9 
---

### 📌 Task Details
- `deploy.sh` 파일을 로컬에서 `scp` 전달하는 방식이 아닌, EC2에서 생성하는 방식으로 수정

---

### 💬 Review Requirements (Optional)

