### PR TITLE
fix: `Dockerfile` JDK 버전 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17.0.1-jdk-slim
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY ./build/libs/*.jar /app/app.jar
 EXPOSE 8080


### PR DESCRIPTION
### ✨ Related Issue
- #9 
---

### 📌 Task Details
- `Dockerfile`의 JDK 버전을 17 → 21 로 정정

---

### 💬 Review Requirements (Optional)

