### PR TITLE
🚨 VectorDB 초기 적재 트리거 수정

### DIFF
--- a/src/main/java/pingpong/backend/domain/notion/service/NotionDatabaseQueryService.java
+++ b/src/main/java/pingpong/backend/domain/notion/service/NotionDatabaseQueryService.java
@@ -147,6 +147,7 @@ public class NotionDatabaseQueryService {
     private ResponseEntity<String> callApi(Long teamId, Supplier<ResponseEntity<String>> supplier) {
         ResponseEntity<String> response = notionTokenService.executeWithRefresh(teamId, supplier);
         if (!response.getStatusCode().is2xxSuccessful()) {
+            log.warn("Notion API 오류 응답 — status={} body={}", response.getStatusCode().value(), response.getBody());
             throw new CustomException(NotionErrorCode.NOTION_API_ERROR);
         }
         return response;

--- a/src/main/java/pingpong/backend/domain/notion/service/NotionFacade.java
+++ b/src/main/java/pingpong/backend/domain/notion/service/NotionFacade.java
@@ -62,8 +62,6 @@ public class NotionFacade {
             notion = resolveAndPersistDatabaseId(teamId);
         }
 
-        eventPublisher.publishEvent(new NotionInitialIndexEvent(teamId));
-
         return new NotionOAuthExchangeResponse(
                 true,
                 notion.getWorkspaceId(),
@@ -84,9 +82,11 @@ public class NotionFacade {
         return notionConnectionApiService.listCandidateDatabases(teamId);
     }
 
+    @Transactional
     public void setPrimaryDatabase(Long teamId, Member member, String databaseId) {
         notionConnectionService.assertTeamAccess(teamId, member);
         notionConnectionApiService.connectDatabase(teamId, databaseId);
+        eventPublisher.publishEvent(new NotionInitialIndexEvent(teamId));
     }
 
     @IndexOnRead(


### PR DESCRIPTION
### ✨ Related Issue
- #35 
---

### 📌 Task Details
- databaseId가 확정되지 않은 OAuth 시점 대신, `PUT /databases/primary` 데이터베이스 선택 완료 후 초기 적재 이벤트 발행. 


---

### 💬 Review Requirements (Optional)

