### PR TITLE
✨엔드포인트 연동 상태 세분화 및 pm 전용 엔드포인트 연동 상태 조회 api 구현

### DIFF
--- a/src/main/java/pingpong/backend/domain/flow/FlowImage.java
+++ b/src/main/java/pingpong/backend/domain/flow/FlowImage.java
@@ -21,8 +21,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import pingpong.backend.domain.flow.dto.request.FlowCreateRequest;
-import pingpong.backend.domain.team.Team;
+import pingpong.backend.domain.flow.enums.UploadStatus;
 
 @Getter
 @Entity

--- a/src/main/java/pingpong/backend/domain/flow/FlowImageEndpoint.java
+++ b/src/main/java/pingpong/backend/domain/flow/FlowImageEndpoint.java
@@ -15,6 +15,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import pingpong.backend.domain.flow.enums.FlowEndpointLinkStatus;
 import pingpong.backend.domain.swagger.Endpoint;
 
 @Getter
@@ -63,7 +64,7 @@ public class FlowImageEndpoint {
 		m.x = x;
 		m.y = y;
 		m.isChanged = ep.getIsChanged();
-		m.isLinked = false;
+		m.isLinked=false;
 		return m;
 	}
 
@@ -72,9 +73,8 @@ public class FlowImageEndpoint {
 		this.y = y;
 	}
 
-	public Boolean markLinked() {
+	public void markLinked() {
 		this.isLinked = true;
-		return null;
 	}
 
 	public void markChanged() {

--- a/src/main/java/pingpong/backend/domain/flow/dto/response/FlowImageResponse.java
+++ b/src/main/java/pingpong/backend/domain/flow/dto/response/FlowImageResponse.java
@@ -1,6 +1,6 @@
 package pingpong.backend.domain.flow.dto.response;
 
-import pingpong.backend.domain.flow.UploadStatus;
+import pingpong.backend.domain.flow.enums.UploadStatus;
 
 public record FlowImageResponse(
 	Long imageId,

--- a/src/main/java/pingpong/backend/domain/flow/enums/EndpointLinkStatus.java
+++ b/src/main/java/pingpong/backend/domain/flow/enums/EndpointLinkStatus.java
@@ -1,0 +1,11 @@
+package pingpong.backend.domain.flow.enums;
+
+/**
+ * 엔드포인트에 대한 status
+ */
+public enum EndpointLinkStatus {
+	BACKEND_IN_PROGRESS,
+	BACKEND_DEPLOYED,
+	FRONTEND_IN_PROGRESS,
+	FULLY_INTEGRATED
+}

--- a/src/main/java/pingpong/backend/domain/flow/enums/FlowEndpointLinkStatus.java
+++ b/src/main/java/pingpong/backend/domain/flow/enums/FlowEndpointLinkStatus.java
@@ -1,0 +1,10 @@
+package pingpong.backend.domain.flow.enums;
+
+/**
+ * 이미지에 할당된 엔드포인트들에 대한 status
+ */
+public enum FlowEndpointLinkStatus {
+	BACKEND_IN_PROGRESS,
+	FRONTEND_IN_PROGRESS, //화면에 API 할당
+	FULLY_INTEGRATED //연동 완료
+}

--- a/src/main/java/pingpong/backend/domain/flow/enums/UploadStatus.java
+++ b/src/main/java/pingpong/backend/domain/flow/enums/UploadStatus.java
@@ -1,4 +1,4 @@
-package pingpong.backend.domain.flow;
+package pingpong.backend.domain.flow.enums;
 
 public enum UploadStatus {
 	PENDING,

--- a/src/main/java/pingpong/backend/domain/flow/repository/FlowImageEndpointRepository.java
+++ b/src/main/java/pingpong/backend/domain/flow/repository/FlowImageEndpointRepository.java
@@ -22,6 +22,7 @@ public interface FlowImageEndpointRepository extends JpaRepository<FlowImageEndp
 	List<FlowImageEndpoint> findMappingsByImageId(@Param("flowImageId") Long flowImageId);
 	Optional<FlowImageEndpoint> findByImageIdAndEndpointId(Long flowImageId, Long endpointId);
 	List<FlowImageEndpoint> findAllByImageId(Long imageId);
+	List<FlowImageEndpoint> findAllByEndpointId(Long endpointId);
 
 	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	@Query("""

--- a/src/main/java/pingpong/backend/domain/flow/service/FlowService.java
+++ b/src/main/java/pingpong/backend/domain/flow/service/FlowService.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import pingpong.backend.domain.flow.Flow;
 import pingpong.backend.domain.flow.FlowImageEndpoint;
-import pingpong.backend.domain.flow.UploadStatus;
+import pingpong.backend.domain.flow.enums.UploadStatus;
 import pingpong.backend.domain.flow.dto.ImageUploadDto;
 import pingpong.backend.domain.flow.dto.request.FlowCreateRequest;
 import pingpong.backend.domain.flow.dto.request.FlowEndpointAssignRequest;

--- a/src/main/java/pingpong/backend/domain/swagger/Endpoint.java
+++ b/src/main/java/pingpong/backend/domain/swagger/Endpoint.java
@@ -54,6 +54,10 @@ public class Endpoint {
 	@Column(columnDefinition = "TEXT")
 	private String description;
 
+	//해당 엔드포인트 연동 완료 여부
+	@Column
+	private Boolean isCompleted;
+
 	@Column
 	private String operationId;
 
@@ -95,11 +99,15 @@ public class Endpoint {
 	@ManyToOne(fetch = FetchType.LAZY)
 	private SwaggerSnapshot snapshot;
 
+	public void markCompleted() {
+		this.isCompleted = true;
+	}
 
 	public void markCreated(LocalDateTime createdAt, Member createdBy,SwaggerSnapshot snapshot) {
 		this.createdAt = createdAt;
 		this.createdBy = createdBy;
 		this.snapshot = snapshot;
+		this.isCompleted = false;
 
 	}
 
@@ -107,6 +115,7 @@ public class Endpoint {
 	public void applyDiff(Endpoint prev) {
 		if (prev == null) {
 			this.isChanged = true;
+			this.isCompleted=false;
 			this.changeType = ChangeType.CREATED;
 			return;
 		}
@@ -117,6 +126,7 @@ public class Endpoint {
 			!Objects.equals(this.responseSchemaHash, prev.getResponseSchemaHash());
 		boolean changed = requestChanged || responseChanged;
 		this.isChanged = changed;
+		this.isCompleted=false;
 
 		if (!changed) {
 			return;

--- a/src/main/java/pingpong/backend/domain/swagger/controller/SwaggerController.java
+++ b/src/main/java/pingpong/backend/domain/swagger/controller/SwaggerController.java
@@ -23,6 +23,7 @@ import pingpong.backend.domain.swagger.dto.response.ApiExecuteResponse;
 import pingpong.backend.domain.swagger.dto.response.EndpointDetailResponse;
 import pingpong.backend.domain.swagger.dto.response.EndpointGroupResponse;
 import pingpong.backend.domain.swagger.dto.response.EndpointResponse;
+import pingpong.backend.domain.swagger.dto.response.EndpointStatusResponse;
 import pingpong.backend.domain.swagger.service.ApiExecuteService;
 import pingpong.backend.domain.swagger.service.EndpointService;
 import pingpong.backend.domain.swagger.service.SwaggerService;
@@ -35,8 +36,8 @@ import pingpong.backend.global.response.result.SuccessResponse;
 public class SwaggerController {
 
 	private final SwaggerService swaggerService;
-	private final EndpointService endpointService;
 	private final ApiExecuteService apiExecuteService;
+	private final EndpointService endpointService;
 
 	@Hidden
 	@GetMapping("/api/v1/swagger/{teamId}")
@@ -116,7 +117,7 @@ public class SwaggerController {
 	}
 
 	@PatchMapping("/api/v1/flow-images/{flowImageId}/endpoints/{endpointId}/complete")
-	@Operation(summary = "엔드포인트 연동 상태 완료로 변경", description = "해당 API를 연동 완료시 요청해주시면 됩니다.")
+	@Operation(summary = "엔드포인트 연동 상태 완료로 변경", description = "FE가 해당 엔드포인트를 연동 완료 시 호출하는 API입니다.")
 	public SuccessResponse<Boolean> completeEndpoint(
 		@PathVariable Long flowImageId,
 		@PathVariable Long endpointId,
@@ -124,5 +125,13 @@ public class SwaggerController {
 	) {
 		endpointService.completeEndpoint(flowImageId, endpointId, member);
 		return SuccessResponse.ok();
+	}
+
+	@GetMapping("/api/v1/pm/progress/{endpointId}")
+	@Operation(summary = "PM입장에서 엔드포인트 별 연동 상태 조회")
+	public SuccessResponse<EndpointStatusResponse> getEndpointStatus(
+		@PathVariable Long endpointId
+	){
+		return SuccessResponse.ok(endpointService.getEndpointStatus(endpointId));
 	}
 }

--- a/src/main/java/pingpong/backend/domain/swagger/dto/response/EndpointStatusResponse.java
+++ b/src/main/java/pingpong/backend/domain/swagger/dto/response/EndpointStatusResponse.java
@@ -1,0 +1,44 @@
+package pingpong.backend.domain.swagger.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import pingpong.backend.domain.flow.enums.FlowEndpointLinkStatus;
+import pingpong.backend.domain.swagger.Endpoint;
+import pingpong.backend.domain.swagger.enums.CrudMethod;
+
+@Schema(description = "endpoint 전부를 보여줍니다")
+public record EndpointStatusResponse(
+
+	@Schema(description = "endpoint ID")
+	Long endpointId,
+
+	@Schema(description = "endpoint 연동 상태")
+	FlowEndpointLinkStatus status,
+
+	@Schema(description = "태그명")
+	String tag,
+
+	@Schema(description = "엔드포인트 path")
+	String path,
+
+	@Schema(description = "method")
+	CrudMethod method,
+
+	@Schema(description = "엔드포인트 요약")
+	String summary
+
+) {
+
+	public static EndpointStatusResponse of(
+		Endpoint endpoint,
+		FlowEndpointLinkStatus status
+	) {
+		return new EndpointStatusResponse(
+			endpoint.getId(),
+			status,
+			endpoint.getTag(),
+			endpoint.getPath(),
+			endpoint.getMethod(),
+			endpoint.getSummary()
+		);
+	}
+}

--- a/src/main/java/pingpong/backend/global/storage/service/PresignedUrlService.java
+++ b/src/main/java/pingpong/backend/global/storage/service/PresignedUrlService.java
@@ -1,9 +1,6 @@
 package pingpong.backend.global.storage.service;
 
-import java.net.URL;
-import java.nio.file.AccessDeniedException;
 import java.time.Duration;
-import java.util.Date;
 
 import org.springframework.beans.factory.annotation.Value;
 
@@ -14,11 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import pingpong.backend.domain.flow.FlowImage;
-import pingpong.backend.domain.flow.UploadStatus;
 import pingpong.backend.domain.flow.repository.FlowImageRepository;
-import pingpong.backend.domain.member.Member;
-import pingpong.backend.global.exception.CustomException;
 import pingpong.backend.global.storage.dto.ImageUploadType;
 import pingpong.backend.global.storage.dto.request.PresignedUrlRequest;
 import pingpong.backend.global.storage.dto.response.PresignedUrlResponse;


### PR DESCRIPTION
### ✨ Related Issue

 - #81 

---

### 📌 Task Details
- Fe : FlowImageEndpoint 엔티티의 isLInked boolean 값으로 연동 상태 체크할 수 있도록 함
- PM: 별도의 필드 조회가 아닌, "PM전용 엔드포인트 별 상태 조회" API를 통해 연동 상태 체크할 수 있도록 함
  - BACKEND_IN_PROGRESS,FRONTEND_IN_PROGRESS, FULLY INTEGRATED -> 총 3개의 상태로 관리
  - `/api/v1/pm/progress/{endpointId}`

---

### 💬 Review Requirements (Optional)

