### PR TITLE
♻️엔드포인트 단위로 업데이트 여부 파악할 수 있도록 수정

### DIFF
--- a/src/main/java/pingpong/backend/domain/swagger/controller/SwaggerController.java
+++ b/src/main/java/pingpong/backend/domain/swagger/controller/SwaggerController.java
@@ -119,7 +119,7 @@ public class SwaggerController {
 	public SuccessResponse<List<EndpointResponse>> getChangedEndpointList(
 		@RequestParam Long teamId
 	) {
-		return SuccessResponse.ok(endpointService.getEndpointList(teamId));
+		return SuccessResponse.ok(endpointService.getChangedEndpointList(teamId));
 	}
 
 	@PostMapping("/api/v1/endpoints/{endpointId}/execute")

--- a/src/main/java/pingpong/backend/domain/swagger/dto/response/EndpointResponse.java
+++ b/src/main/java/pingpong/backend/domain/swagger/dto/response/EndpointResponse.java
@@ -1,5 +1,7 @@
 package pingpong.backend.domain.swagger.dto.response;
 
+import java.util.Optional;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import pingpong.backend.domain.swagger.Endpoint;
 import pingpong.backend.domain.swagger.enums.ChangeType;
@@ -23,8 +25,8 @@ public record EndpointResponse (
 	@Schema(description = "엔드포인트 요약")
 	String summary,
 
-	// @Schema(description="endpoint 변화 여부")
-	// Boolean isChanged,
+	@Schema(description="endpoint 변화 여부")
+	Boolean isChanged,
 
 	@Schema(description="endpoint 변화 타입")
 	ChangeType changeType
@@ -32,6 +34,13 @@ public record EndpointResponse (
 ){
 
 	public static EndpointResponse toDto(Endpoint e){
-		return new EndpointResponse(e.getId(),e.getTag(),e.getPath(), e.getMethod(), e.getSummary(), e.getChangeType());
+		return new EndpointResponse(
+			e.getId(),
+			Optional.ofNullable(e.getTag()).orElse("default"),
+			e.getPath(),
+			e.getMethod(),
+			e.getSummary(),
+			e.getIsChanged(),
+			e.getChangeType());
 	}
 }

--- a/src/main/java/pingpong/backend/domain/swagger/service/EndpointService.java
+++ b/src/main/java/pingpong/backend/domain/swagger/service/EndpointService.java
@@ -56,6 +56,30 @@ public class EndpointService {
 	}
 
 	/**
+	 * 해당 프로젝트에 속한 변경된 모든 엔드포인트 조회
+	 */
+	@Transactional(readOnly = true)
+	public List<EndpointResponse> getChangedEndpointList(Long teamId) {
+
+		Optional<SwaggerSnapshot> latest =
+			swaggerSnapshotRepository.findTopByTeamIdOrderByIdDesc(teamId);
+
+		if (latest.isEmpty()) {
+			return List.of();
+		}
+
+		Long snapshotId = latest.get().getId();
+
+		List<Endpoint> endpoints =
+			endpointRepository.findBySnapshotId(snapshotId);
+
+		return endpoints.stream()
+			.filter(e -> Boolean.TRUE.equals(e.getIsChanged()))
+			.map(EndpointResponse::toDto)
+			.toList();
+	}
+
+	/**
 	 * path에 검색어가 포함된 엔드포인트 조회 (최신 스냅샷 기준, case-insensitive)
 	 */
 	@Transactional(readOnly = true)

--- a/src/main/java/pingpong/backend/domain/swagger/service/SwaggerService.java
+++ b/src/main/java/pingpong/backend/domain/swagger/service/SwaggerService.java
@@ -305,16 +305,25 @@ public class SwaggerService {
 		// endpoint diff
 		Map<String, List<EndpointResponse>> grouped =
 			allEndpoints.stream()
-				.filter(e -> Boolean.TRUE.equals(e.getIsChanged()))
 				.map(EndpointResponse::toDto)
 				.collect(Collectors.groupingBy(EndpointResponse::tag));
 
 		return grouped.entrySet().stream()
-			.map(e->new EndpointGroupResponse(
-				SnapshotDiffStatus.CHANGED,
-				e.getKey(),
-				e.getValue()
-			))
+			.map(e -> {
+				List<EndpointResponse> endpointResponses = e.getValue();
+
+				boolean hasChanged = endpointResponses.stream()
+					.anyMatch(ep -> Boolean.TRUE.equals(ep.isChanged()));
+
+				SnapshotDiffStatus status =
+					hasChanged ? SnapshotDiffStatus.CHANGED : SnapshotDiffStatus.NOT_CHANGED;
+
+				return new EndpointGroupResponse(
+					status,
+					e.getKey(),
+					endpointResponses
+				);
+			})
 			.toList();
 	}
 


### PR DESCRIPTION
### ✨ Related Issue

#131 

---

### 📌 Task Details
- 변화한 엔드포인트들만 조회하는 API `api/v1/endpoints/changed` 로직 수정
- `/sync` API에서 엔드포인트 단위로 변화여부 파악할 수 있는 **isChanged** 필드 추가 

---

### 💬 Review Requirements (Optional)

