### PR TITLE
🐛 토큰 검증 시 HS256 제약 제거 #146

### DIFF
--- a/mcp-server/src/auth.ts
+++ b/mcp-server/src/auth.ts
@@ -17,7 +17,17 @@ function getSecretKey(): Uint8Array {
 
 export async function verifyMcpToken(token: string): Promise<McpContext> {
   const key = getSecretKey();
-  const { payload } = await jwtVerify(token, key, { algorithms: ['HS256'] });
+
+  // JWT header에서 실제 알고리즘 확인 (디버깅용)
+  try {
+    const headerB64 = token.split('.')[0];
+    const header = JSON.parse(Buffer.from(headerB64, 'base64url').toString());
+    console.log(`[AUTH] JWT header: alg=${header.alg}, typ=${header.typ}`);
+  } catch {
+    console.log('[AUTH] Failed to decode JWT header');
+  }
+
+  const { payload } = await jwtVerify(token, key);
 
   const email = payload['email'] as string;
   const teamId = Number(payload['teamId']);


### PR DESCRIPTION
### ✨ Related Issue
- #146 
---

### 📌 Task Details

- MCP 인증 실패 로그 분석
  - Claude Code에서 MCP 서버 연결 시 인증 실패가 발생하여 서버 로그를 확인하였다.
  - 로그를 통해 **Authorization 헤더 누락 문제와 JWT 알고리즘 검증 문제**가 확인되었다.

1. Authorization 헤더 누락 요청 발생: 초기 요청에서 `Authorization` 헤더 없이 `/mcp` 엔드포인트가 호출되었다.
MCP initialize 요청이 **토큰 없이 전송됨** → 서버에서 인증 실패 처리

```
[REQ] POST /mcp
Authorization: none
Content-Type: application/json
Body: {"method":"initialize", ...}

[AUTH] Missing or invalid Authorization header
```

2. OAuth 메타데이터 조회 요청: Claude Code가 OAuth 서버 정보를 확인하기 위해 `.well-known/oauth-authorization-server` 엔드포인트를 반복 호출하였다.
OAuth 인증 흐름 초기 단계: Authorization Server metadata 탐색 과정

```
[REQ] GET /.well-known/oauth-authorization-server
Authorization: none
```

3. Authorization 헤더 포함 요청: 이후 Authorization 헤더가 포함된 요청이 `/mcp`로 전송됨: JWT 토큰이 포함된 정상적인 인증 시도

```
[REQ] POST /mcp
Authorization: Bearer (present, length=224)
Content-Type: application/json
Body: {"method":"initialize", ...}
```


4. **JWT 검증 실패**: 토큰 검증 단계에서 JWT header의 `alg` 값이 서버 허용 목록에 없어서 인증이 실패하였다: JWT header의 `alg` 값이 서버 검증 로직에서 허용되지 않음 → 토큰 자체는 존재하지만 **알고리즘 검증 단계에서 실패**

```
[AUTH] Token verification failed: "alg" (Algorithm) Header Parameter value not allowed
```

---

### 💬 Review Requirements (Optional)

