### PR TITLE
🐛 요청 Header 누락 시 500 오류 반환 에러

### DIFF
--- a/src/main/java/pingpong/backend/global/exception/ExceptionAdvice.java
+++ b/src/main/java/pingpong/backend/global/exception/ExceptionAdvice.java
@@ -9,6 +9,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -47,6 +48,17 @@ public class ExceptionAdvice {
                 .errorMessage(e.getMessage())
                 .build();
         return ErrorResponse.ok(ErrorCode.SERVER_UNTRACKED_ERROR.getErrorCode(), ErrorCode.SERVER_UNTRACKED_ERROR.getMessage(), serverErrorData);
+    }
+
+    /**
+     * 필수 @RequestHeader 누락 예외 (400)
+     */
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse<String> handleMissingHeader(MissingRequestHeaderException e) {
+        return ErrorResponse.ok(PARAMETER_VALIDATION_ERROR.getErrorCode(),
+                "'" + e.getHeaderName() + "' 헤더가 필요합니다.",
+                e.getMessage());
     }
 
     /**


### PR DESCRIPTION
### ✨ Related Issue
- #196 
---

### 📌 Task Details
- ExceptionAdvice에 MissingRequestHeaderException 핸들러를 추가하여 클라이언트의 잘못된 요청에는 400대 에러를 반환하도록 수정
<img width="1000" height="301" alt="image" src="https://github.com/user-attachments/assets/a621a229-9b96-4a0f-88b4-2de5edb408d0" />


---

### 💬 Review Requirements (Optional)

