### PR TITLE
🐛 `ci-cd.yml`에서 불필요한 platform 제거

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -102,7 +102,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/grad02-app:${{ github.sha }}
             ${{ secrets.DOCKERHUB_USERNAME }}/grad02-app:latest
@@ -113,7 +113,7 @@ jobs:
           context: ./mcp-server
           file: ./mcp-server/Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/grad02-mcp:${{ github.sha }}
             ${{ secrets.DOCKERHUB_USERNAME }}/grad02-mcp:latest


### PR DESCRIPTION
### ✨ Related Issue
- #200 

---

### 📌 Task Details
- 배포 서버가 x86_64이므로 GitHub Actions Docker 빌드에서 불필요한 linux/arm64 플랫폼을 제거해 npm install 단계의 QEMU Illegal instruction 오류를 방지한다.


---

### 💬 Review Requirements (Optional)

